### PR TITLE
chore: revert to dnsmasq-dnssec=~2.85

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.19
+FROM alpine:3.14
 
-RUN apk --no-cache add dnsmasq-dnssec=~2.90
+RUN apk --no-cache add dnsmasq-dnssec=~2.85
 EXPOSE 53 53/udp
 ENTRYPOINT ["dnsmasq", "-k"]


### PR DESCRIPTION
The recent 0.1.0 release of dnsmasq updated the dnsmasq version to 2.90, which has proven incompatible with some macos setups. This PR reverts it to the 2.85 (the issue presents in 2.86) whilst we investigate

closes #19 