### PR TITLE
Add BATS tests for dnsmasq

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -32,26 +32,26 @@ jobs:
             org.opencontainers.image.description=dnsmasq DNS proxy, configured for use with the pygmy stack
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -61,15 +61,15 @@ jobs:
 
   test:
     needs: docker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - 
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # Establish some SSH keys.
       - 
         name: Setup SSH
         run: |
-          eval $(ssh-agent);
+          eval "$(ssh-agent)";
           ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N "";
           ssh-keygen -t rsa -q -f "$HOME/.ssh/id_pwd" -N "passphrase";
           ssh-add;
@@ -77,33 +77,50 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           # list of Docker images to use as base name for tags
           images: |
             ghcr.io/${{ github.repository_owner }}/dnsmasq
           flavor: |
             latest=false
+      -
+        name: Set single image tag
+        id: single_tag
+        run: |
+          echo "tag=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)" >> "$GITHUB_OUTPUT"
       - 
         name: Find and Replace
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "ghcr.io/pygmystack/dnsmasq:main"
-          replace: ${{ steps.meta.outputs.tags }}
-          include: "examples/**"
-      - 
-        name: Show changes
+        env:
+          IMAGE_TAG: ${{ steps.single_tag.outputs.tag }}
         run: |
+          find examples/ -type f -exec sed -i.bak "s|ghcr.io/pygmystack/dnsmasq:main|${IMAGE_TAG}|g" {} \;
+          find examples/ -name "*.bak" -delete
           grep -n ghcr examples/*
       - 
-        name: Install pygmy and dockerize via brew
+        name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@fb0fe15d936a80ac0ba4c6cee691bc3da3f00f4e # main
+      - 
+        name: Install homebrew packages
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          HOMEBREW_NO_ENV_HINTS: 1
         run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)";
-          brew tap pygmystack/pygmy;
-          brew install pygmy;
+          brew install bats-core;
           brew install dockerize;
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH;
+          brew install pygmystack/pygmy/pygmy;
           pygmy version;
+      -
+        name: Pull image for tests
+        run: docker pull ${{ steps.single_tag.outputs.tag }}
+      - 
+        name: Run BATS tests
+        env:
+          IMAGE_NAME: ${{ steps.single_tag.outputs.tag }}
+        run: |
+          bats --tap tests/image_structure.bats
+          bats --tap tests/runtime.bats
       - 
         name: Switch pygmy configs from vanilla to basic
         run: |
@@ -123,7 +140,7 @@ jobs:
           pygmy --config examples/pygmy.basic.yml export -o ./exported-config.yml
           cat ./exported-config.yml
           echo "Checking image references in started containers...";
-          docker container inspect amazeeio-dnsmasq  | jq '.[].Config.Image' | grep '${{ steps.meta.outputs.tags }}';
+          docker container inspect amazeeio-dnsmasq  | jq '.[].Config.Image' | grep -F '${{ steps.single_tag.outputs.tag }}';
       - 
         name: Resolv file test
         run: |
@@ -185,7 +202,7 @@ jobs:
           pygmy --config examples/pygmy.yml export -o ./exported-config-2.yml
           cat ./exported-config-2.yml
           echo "Checking image references in started containers...";
-          docker container inspect amazeeio-dnsmasq   | jq '.[].Config.Image' | grep '${{ steps.meta.outputs.tags }}';
+          docker container inspect amazeeio-dnsmasq   | jq '.[].Config.Image' | grep -F '${{ steps.single_tag.outputs.tag }}';
       - 
         name: SSH Key test
         run: |
@@ -201,14 +218,14 @@ jobs:
         name: "[Example] Drupal Base"
         run: |
           cd lagoon-examples/drupal-base;
-          docker-compose -p drupal-base up -d;
-          docker-compose -p drupal-base exec -T cli composer install;
+          docker compose -p drupal-base up -d;
+          docker compose -p drupal-base exec -T cli composer install;
           dockerize -wait http://drupal-base.docker.amazee.io:80 -timeout 10s;
-          curl --HEAD http://drupal-base.docker.amazee.io;
-          curl --HEAD http://drupal-base.docker.amazee.io | grep -i "x-lagoon";
+          curl --head http://drupal-base.docker.amazee.io;
+          curl --head http://drupal-base.docker.amazee.io | grep -i "x-lagoon";
           pygmy --config examples/pygmy.yml status | grep '\- http://drupal-base.docker.amazee.io';
-          docker-compose -p drupal-base down;
-          docker-compose -p drupal-base rm;
+          docker compose -p drupal-base down;
+          docker compose -p drupal-base rm -f;
           cd ../../;
       - 
         name: Test the stop command

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+IMAGE_NAME ?= pygmystack/dnsmasq
+IMAGE_TAG  ?= test
+FULL_IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help build test test-bats test-structure test-runtime up down shell clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the Docker image
+	docker build --tag $(FULL_IMAGE) .
+
+test: build ## Build image and run all tests (requires: brew install bats-core)
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "Error: bats is not installed. Install with: brew install bats-core"; \
+		exit 1; \
+	}
+	IMAGE_NAME=$(FULL_IMAGE) bats --tap tests/
+
+test-bats: ## Run all BATS tests without rebuilding the image
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "Error: bats is not installed. Install with: brew install bats-core"; \
+		exit 1; \
+	}
+	IMAGE_NAME=$(FULL_IMAGE) bats --tap tests/
+
+test-structure: ## Run image structure tests only (no running container required)
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "Error: bats is not installed. Install with: brew install bats-core"; \
+		exit 1; \
+	}
+	IMAGE_NAME=$(FULL_IMAGE) bats --tap tests/image_structure.bats
+
+test-runtime: ## Run container runtime and DNS resolution tests
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "Error: bats is not installed. Install with: brew install bats-core"; \
+		exit 1; \
+	}
+	IMAGE_NAME=$(FULL_IMAGE) bats --tap tests/runtime.bats
+
+up: ## Start the stack with docker compose
+	docker compose up -d
+
+down: ## Stop the stack with docker compose
+	docker compose down
+
+shell: ## Open an interactive shell inside the container
+	docker run --rm -it --entrypoint sh $(FULL_IMAGE)
+
+clean: ## Remove the local test Docker image
+	docker rmi $(FULL_IMAGE) 2>/dev/null || true

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Image structure tests — verify the binary, DNSSEC capability, and image
+# metadata baked into the dnsmasq image.  These tests run ephemeral containers
+# and do not require access to the Docker socket.
+
+IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
+
+# ---------------------------------------------------------------------------
+# Binaries
+# ---------------------------------------------------------------------------
+
+@test "dnsmasq binary is available in PATH" {
+    run docker run --rm --entrypoint which "${IMAGE}" dnsmasq
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "dnsmasq version is 2.85.x" {
+    run docker run --rm --entrypoint sh "${IMAGE}" -c 'dnsmasq --version 2>&1'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2.85" ]]
+}
+
+@test "dnsmasq is built with DNSSEC support" {
+    run docker run --rm --entrypoint sh "${IMAGE}" -c 'dnsmasq --version 2>&1'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "DNSSEC" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Exposed ports (image metadata)
+# ---------------------------------------------------------------------------
+
+@test "image exposes port 53/tcp" {
+    run docker inspect --format='{{json .Config.ExposedPorts}}' "${IMAGE}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "53/tcp" ]]
+}
+
+@test "image exposes port 53/udp" {
+    run docker inspect --format='{{json .Config.ExposedPorts}}' "${IMAGE}"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "53/udp" ]]
+}

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # Image structure tests — verify the binary, DNSSEC capability, and image
 # metadata baked into the dnsmasq image.  These tests run ephemeral containers
-# and do not require access to the Docker socket.
+# and require Docker to be available on the host (no long-running containers).
 
 IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
 
@@ -78,6 +78,20 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     dns_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_a}\").IPAddress}}" "${dns_c}")"
     net_a_subnet="$(docker network inspect -f '{{(index .IPAM.Config 0).Subnet}}' "${net_a}")"
 
+    if [ -z "${dns_ip}" ]; then
+        echo "dns_ip is empty; docker inspect failed or returned no IP for container '${dns_c}' on network '${net_a}'" >&2
+        docker rm -f "${dns_c}" "${rtr_c}" 2>/dev/null || true
+        docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
+        return 1
+    fi
+
+    if [ -z "${net_a_subnet}" ]; then
+        echo "net_a_subnet is empty; docker network inspect failed or returned no subnet for network '${net_a}'" >&2
+        docker rm -f "${dns_c}" "${rtr_c}" 2>/dev/null || true
+        docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
+        return 1
+    fi
+
     # Router with IP forwarding bridges both networks. --privileged is used
     # to ensure /proc/sys/net/ipv4/ip_forward is writable in all CI environments.
     docker run -d --name "${rtr_c}" \
@@ -89,7 +103,16 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     local rtr_b_ip
     rtr_b_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_b}\").IPAddress}}" "${rtr_c}")"
 
-    sleep 2
+    # Wait until the router container is running before sending traffic.
+    local wait_secs=0
+    until [ "$(docker inspect -f '{{.State.Running}}' "${rtr_c}" 2>/dev/null)" = "true" ]; do
+        sleep 1
+        wait_secs=$((wait_secs + 1))
+        if [ "$wait_secs" -ge 20 ]; then
+            echo "Timed out waiting for router container to start" >&2
+            break
+        fi
+    done
 
     # Client on net-b routes through the router and sends the query. nslookup
     # will time out (no return path) — that is expected and ignored. We only
@@ -102,7 +125,15 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
             timeout 3 nslookup local-service-test.docker.amazee.io ${dns_ip}
         " >/dev/null 2>&1 || true
 
-    sleep 1
+    # Wait (bounded) for dnsmasq to log the query rather than using a fixed sleep.
+    wait_secs=0
+    until docker logs "${dns_c}" 2>&1 | grep -q "local-service-test.docker.amazee.io"; do
+        sleep 1
+        wait_secs=$((wait_secs + 1))
+        if [ "$wait_secs" -ge 10 ]; then
+            break
+        fi
+    done
 
     # If local-service were active dnsmasq would silently drop the query and
     # nothing would appear in its log. Presence of the query name confirms

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -28,6 +28,89 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
 }
 
 # ---------------------------------------------------------------------------
+# Configuration — local-service disabled
+# ---------------------------------------------------------------------------
+
+@test "dnsmasq serves DNS to clients whose source IP is not on a directly-connected subnet" {
+    # Functionally validates that the local-service restriction is NOT active.
+    # The default /etc/dnsmasq.conf in Alpine ships with "local-service" enabled,
+    # which causes dnsmasq to silently drop queries from clients whose source IP
+    # is not on a subnet directly attached to the server.  The Dockerfile
+    # comments that line out so that dnsmasq answers all clients — a requirement
+    # for the pygmy stack, where the host resolver queries the containerised
+    # dnsmasq across Docker's bridge network.
+    #
+    # Topology used by this test:
+    #   net-a (172.28.200.0/24) ── dnsmasq container
+    #              │
+    #         router (ip_forward=1, one leg on each net)
+    #              │
+    #   net-b (172.29.200.0/24) ── DNS client
+    #
+    # The client's source IP (172.29.200.x) is NOT in net-a, so with
+    # local-service active dnsmasq would refuse the query.  Without it, the
+    # query is answered.
+
+    local suffix net_a net_b dns_c rtr_c
+    suffix="$(openssl rand -hex 4)"
+    net_a="dnsmasq-ls-a-${suffix}"
+    net_b="dnsmasq-ls-b-${suffix}"
+    dns_c="dnsmasq-ls-dns-${suffix}"
+    rtr_c="dnsmasq-ls-rtr-${suffix}"
+
+    # Pre-cleanup in case a previous run left debris.
+    docker rm -f "${dns_c}" "${rtr_c}" 2>/dev/null || true
+    docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
+
+    docker network create --subnet=172.28.200.0/24 "${net_a}"
+    docker network create --subnet=172.29.200.0/24 "${net_b}"
+
+    # dnsmasq is only connected to net-a.
+    docker run -d --name "${dns_c}" \
+        --network "${net_a}" \
+        "${IMAGE}" \
+        --address=/local-service-test.docker.amazee.io/1.2.3.4
+
+    local dns_ip
+    dns_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_a}\").IPAddress}}" "${dns_c}")"
+
+    # Router bridges both networks with IP forwarding enabled.
+    docker run -d --name "${rtr_c}" \
+        --network "${net_a}" \
+        --cap-add NET_ADMIN \
+        --sysctl net.ipv4.ip_forward=1 \
+        alpine sleep 30
+    docker network connect "${net_b}" "${rtr_c}"
+
+    local rtr_b_ip
+    rtr_b_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_b}\").IPAddress}}" "${rtr_c}")"
+
+    # Allow dnsmasq a moment to start.
+    sleep 2
+
+    # Client lives only on net-b.  It routes into net-a via the router and
+    # queries dnsmasq.  Because the source IP (172.29.200.x) is outside net-a,
+    # local-service would reject this if it were still active.
+    run docker run --rm \
+        --network "${net_b}" \
+        --cap-add NET_ADMIN \
+        alpine sh -c "
+            ip route add 172.28.200.0/24 via ${rtr_b_ip} &&
+            nslookup local-service-test.docker.amazee.io ${dns_ip}
+        "
+
+    # Capture results before cleanup so assertions reflect the real outcome.
+    local test_status=$status
+    local test_output="$output"
+
+    docker rm -f "${dns_c}" "${rtr_c}" 2>/dev/null || true
+    docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
+
+    [ "$test_status" -eq 0 ]
+    [[ "$test_output" =~ "1.2.3.4" ]]
+}
+
+# ---------------------------------------------------------------------------
 # Exposed ports (image metadata)
 # ---------------------------------------------------------------------------
 

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -32,24 +32,24 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
 # ---------------------------------------------------------------------------
 
 @test "dnsmasq serves DNS to clients whose source IP is not on a directly-connected subnet" {
-    # Functionally validates that the local-service restriction is NOT active.
-    # The default /etc/dnsmasq.conf in Alpine ships with "local-service" enabled,
-    # which causes dnsmasq to silently drop queries from clients whose source IP
-    # is not on a subnet directly attached to the server.  The Dockerfile
-    # comments that line out so that dnsmasq answers all clients — a requirement
-    # for the pygmy stack, where the host resolver queries the containerised
-    # dnsmasq across Docker's bridge network.
+    # Validates that the local-service restriction is NOT active.
+    # The default Alpine dnsmasq.conf enables "local-service", which silently
+    # drops queries from clients whose source IP is not on a subnet directly
+    # attached to dnsmasq. The Dockerfile comments that line out so all clients
+    # are served — required by the pygmy stack.
     #
-    # Topology used by this test:
-    #   net-a (172.28.200.0/24) ── dnsmasq container
+    # Topology:
+    #   net-a (Docker auto-assigned) ── dnsmasq
     #              │
-    #         router (ip_forward=1, one leg on each net)
+    #         router (--privileged, IP forwarding on)
     #              │
-    #   net-b (172.29.200.0/24) ── DNS client
+    #   net-b (Docker auto-assigned) ── DNS client
     #
-    # The client's source IP (172.29.200.x) is NOT in net-a, so with
-    # local-service active dnsmasq would refuse the query.  Without it, the
-    # query is answered.
+    # The client's source IP is in net-b, not net-a, so local-service would
+    # drop it. We verify dnsmasq received and processed the query by checking
+    # its logs (--log-queries). The DNS reply cannot route back to the client
+    # due to Docker network isolation — that is expected and irrelevant here;
+    # only the client→dnsmasq direction is needed.
 
     local suffix net_a net_b dns_c rtr_c
     suffix="$(openssl rand -hex 4)"
@@ -58,48 +58,57 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     dns_c="dnsmasq-ls-dns-${suffix}"
     rtr_c="dnsmasq-ls-rtr-${suffix}"
 
-    # Pre-cleanup in case a previous run left debris.
     docker rm -f "${dns_c}" "${rtr_c}" 2>/dev/null || true
     docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
 
-    docker network create --subnet=172.28.200.0/24 "${net_a}"
-    docker network create --subnet=172.29.200.0/24 "${net_b}"
+    # Let Docker assign subnets automatically to avoid conflicts with the
+    # runner's existing networks (the root cause of failures with hardcoded IPs).
+    docker network create "${net_a}" >/dev/null
+    docker network create "${net_b}" >/dev/null
 
-    # dnsmasq is only connected to net-a.
+    # dnsmasq on net-a only; logs queries to stderr so docker logs shows them.
     docker run -d --name "${dns_c}" \
         --network "${net_a}" \
         "${IMAGE}" \
-        --address=/local-service-test.docker.amazee.io/1.2.3.4
+        --log-queries \
+        --log-facility=- \
+        --address=/local-service-test.docker.amazee.io/1.2.3.4 >/dev/null
 
-    local dns_ip
+    local dns_ip net_a_subnet
     dns_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_a}\").IPAddress}}" "${dns_c}")"
+    net_a_subnet="$(docker network inspect -f '{{(index .IPAM.Config 0).Subnet}}' "${net_a}")"
 
-    # Router bridges both networks with IP forwarding enabled.
+    # Router with IP forwarding bridges both networks. --privileged is used
+    # to ensure /proc/sys/net/ipv4/ip_forward is writable in all CI environments.
     docker run -d --name "${rtr_c}" \
         --network "${net_a}" \
-        --cap-add NET_ADMIN \
-        --sysctl net.ipv4.ip_forward=1 \
-        alpine sleep 30
-    docker network connect "${net_b}" "${rtr_c}"
+        --privileged \
+        alpine sh -c 'echo 1 > /proc/sys/net/ipv4/ip_forward && tail -f /dev/null' >/dev/null
+    docker network connect "${net_b}" "${rtr_c}" >/dev/null
 
     local rtr_b_ip
     rtr_b_ip="$(docker inspect -f "{{(index .NetworkSettings.Networks \"${net_b}\").IPAddress}}" "${rtr_c}")"
 
-    # Allow dnsmasq a moment to start.
     sleep 2
 
-    # Client lives only on net-b.  It routes into net-a via the router and
-    # queries dnsmasq.  Because the source IP (172.29.200.x) is outside net-a,
-    # local-service would reject this if it were still active.
-    run docker run --rm \
+    # Client on net-b routes through the router and sends the query. nslookup
+    # will time out (no return path) — that is expected and ignored. We only
+    # need the UDP query to reach dnsmasq.
+    docker run --rm \
         --network "${net_b}" \
         --cap-add NET_ADMIN \
         alpine sh -c "
-            ip route add 172.28.200.0/24 via ${rtr_b_ip} &&
-            nslookup local-service-test.docker.amazee.io ${dns_ip}
-        "
+            ip route add ${net_a_subnet} via ${rtr_b_ip} 2>/dev/null || true
+            timeout 3 nslookup local-service-test.docker.amazee.io ${dns_ip}
+        " >/dev/null 2>&1 || true
 
-    # Capture results before cleanup so assertions reflect the real outcome.
+    sleep 1
+
+    # If local-service were active dnsmasq would silently drop the query and
+    # nothing would appear in its log. Presence of the query name confirms
+    # local-service is disabled.
+    run docker logs "${dns_c}" 2>&1
+
     local test_status=$status
     local test_output="$output"
 
@@ -107,7 +116,7 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     docker network rm "${net_a}" "${net_b}" 2>/dev/null || true
 
     [ "$test_status" -eq 0 ]
-    [[ "$test_output" =~ "1.2.3.4" ]]
+    [[ "$test_output" =~ "local-service-test.docker.amazee.io" ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# Runtime tests — start a long-running dnsmasq container and exercise its
+# DNS behaviour.
+#
+# The container is started once for the entire file with two --address rules:
+#   *.docker.amazee.io   → 127.0.0.1
+#   test.example.invalid → 192.0.2.42
+#
+# DNS queries are issued from *inside* the container using the busybox nslookup
+# applet, so no special host-side DNS tooling is required.
+
+bats_require_minimum_version 1.5.0
+
+IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
+
+# Container name variable is set in setup() by reading the suffix written by
+# setup_file().  This ensures all tests share the same name despite BATS
+# re-sourcing the file for each test.
+DNSMASQ_CONTAINER=""
+
+# ---------------------------------------------------------------------------
+# File-level setup / teardown — container is started once for the entire file.
+# ---------------------------------------------------------------------------
+
+setup_file() {
+    # Generate a unique suffix once and persist it so every test in this run
+    # references the same container name (BATS re-sources the file per test).
+    local suffix
+    suffix="$(openssl rand -hex 4)"
+    echo "${suffix}" > "${BATS_SUITE_TMPDIR}/.suffix"
+    DNSMASQ_CONTAINER="dnsmasq-bats-test-${suffix}"
+
+    # Remove any leftover container from a previous (failed) run.
+    docker rm -f "${DNSMASQ_CONTAINER}" 2>/dev/null || true
+
+    docker run -d \
+        --name "${DNSMASQ_CONTAINER}" \
+        "${IMAGE}" \
+        --address=/docker.amazee.io/127.0.0.1 \
+        --address=/test.example.invalid/192.0.2.42
+
+    # Wait for dnsmasq to start accepting DNS queries.
+    local max_wait=15
+    local waited=0
+    until docker exec "${DNSMASQ_CONTAINER}" nslookup test.docker.amazee.io 127.0.0.1 >/dev/null 2>&1; do
+        sleep 1
+        waited=$((waited + 1))
+        if [ "$waited" -ge "$max_wait" ]; then
+            echo "# Timed out waiting for dnsmasq to become ready" >&3
+            docker logs "${DNSMASQ_CONTAINER}" >&3 2>&3
+            return 1
+        fi
+    done
+}
+
+teardown_file() {
+    local suffix
+    suffix="$(cat "${BATS_SUITE_TMPDIR}/.suffix" 2>/dev/null || true)"
+    docker rm -f "dnsmasq-bats-test-${suffix}" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Per-test setup — restore the container name from the stable suffix written
+# by setup_file(), because BATS re-sources the file for every test.
+# ---------------------------------------------------------------------------
+
+setup() {
+    local suffix
+    suffix="$(cat "${BATS_SUITE_TMPDIR}/.suffix" 2>/dev/null || true)"
+    DNSMASQ_CONTAINER="dnsmasq-bats-test-${suffix}"
+}
+
+# ---------------------------------------------------------------------------
+# Container lifecycle
+# ---------------------------------------------------------------------------
+
+@test "container is running" {
+    run docker inspect --format='{{.State.Status}}' "${DNSMASQ_CONTAINER}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "running" ]
+}
+
+@test "dnsmasq process is alive (PID 1 check)" {
+    run docker exec "${DNSMASQ_CONTAINER}" sh -c 'kill -0 1 2>/dev/null && echo alive'
+    [ "$status" -eq 0 ]
+    [ "$output" = "alive" ]
+}
+
+@test "dnsmasq reports its version inside the container" {
+    run docker exec "${DNSMASQ_CONTAINER}" sh -c 'dnsmasq --version 2>&1'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Dnsmasq version" ]]
+}
+
+# ---------------------------------------------------------------------------
+# DNS resolution
+# ---------------------------------------------------------------------------
+
+@test "dnsmasq resolves wildcard *.docker.amazee.io to 127.0.0.1" {
+    run docker exec "${DNSMASQ_CONTAINER}" nslookup test.docker.amazee.io 127.0.0.1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "127.0.0.1" ]]
+}
+
+@test "dnsmasq resolves a second configured address rule" {
+    run docker exec "${DNSMASQ_CONTAINER}" nslookup test.example.invalid 127.0.0.1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "192.0.2.42" ]]
+}

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -33,11 +33,17 @@ setup_file() {
     # Remove any leftover container from a previous (failed) run.
     docker rm -f "${DNSMASQ_CONTAINER}" 2>/dev/null || true
 
-    docker run -d \
+    # Start the container and fail fast if docker run does not succeed.
+    local run_output
+    if ! run_output="$(docker run -d \
         --name "${DNSMASQ_CONTAINER}" \
         "${IMAGE}" \
         --address=/docker.amazee.io/127.0.0.1 \
-        --address=/test.example.invalid/192.0.2.42
+        --address=/test.example.invalid/192.0.2.42 2>&1)"; then
+        echo "# Failed to start dnsmasq test container" >&3
+        echo "${run_output}" >&3
+        return 1
+    fi
 
     # Wait for dnsmasq to start accepting DNS queries.
     local max_wait=15
@@ -56,7 +62,9 @@ setup_file() {
 teardown_file() {
     local suffix
     suffix="$(cat "${BATS_SUITE_TMPDIR}/.suffix" 2>/dev/null || true)"
-    docker rm -f "dnsmasq-bats-test-${suffix}" 2>/dev/null || true
+    if [ -n "${suffix}" ]; then
+        docker rm -f "dnsmasq-bats-test-${suffix}" 2>/dev/null || true
+    fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces significant improvements to the project's testing and CI/CD infrastructure. The main changes include a comprehensive overhaul of the GitHub Actions workflow for building and testing, the addition of a `Makefile` for local developer workflows, and the introduction of BATS-based integration and structure tests to verify the Docker image's correctness and runtime behavior.

**CI/CD Workflow Modernization and Testing Enhancements:**

*GitHub Actions workflow improvements:*
- Upgraded all major GitHub Actions and Docker actions to their latest versions, now referencing specific commit SHAs for improved security and reliability. The test runner now uses `ubuntu-latest` instead of a fixed version. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L20-R24) [[2]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L35-R54) [[3]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L64-R123)
- Refactored the test job to use a more robust method for updating image tags in example files, replaced the `gha-find-replace` action with direct `sed` usage, and improved the handling of image tags throughout the workflow.
- Improved Homebrew setup by splitting installation steps and ensuring required packages (`bats-core`, `dockerize`, and `pygmy`) are installed in a more reliable way.
- Updated all `docker-compose` commands to use the newer `docker compose` CLI syntax for better compatibility and future-proofing.
- Ensured that image references in running containers are checked against the actual tag used in the workflow, increasing test accuracy. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L126-R143) [[2]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L188-R205)

*Local development and testing:*
- Added a new `Makefile` with targets for building the Docker image, running all or specific BATS tests, starting/stopping the stack, opening a shell in the container, and cleaning up images, greatly simplifying local development and testing.

*Integration and structure tests:*
- Introduced `tests/image_structure.bats` to verify the presence and version of the `dnsmasq` binary, DNSSEC support, image metadata (exposed ports), and correct disabling of the `local-service` restriction.
- Added `tests/runtime.bats` to perform end-to-end runtime tests, ensuring the container starts correctly, the `dnsmasq` process is running, and DNS resolution works as expected for multiple configured rules.