### PR TITLE
Update base image to Alpine 3.23 and dnsmasq to version 2.91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM alpine:3.14
+FROM alpine:3.23
 
-RUN apk --no-cache add dnsmasq-dnssec=~2.85
+RUN apk --no-cache add bash dnsmasq-dnssec=~2.91
+
+RUN sed -i 's/^local-service/\#&/' /etc/dnsmasq.conf
+
 EXPOSE 53 53/udp
 ENTRYPOINT ["dnsmasq", "-k"]

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -15,10 +15,13 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     [ -n "$output" ]
 }
 
-@test "dnsmasq version is 2.91.x" {
+@test "dnsmasq version matches Dockerfile" {
+    local expected_version
+    expected_version="$(grep -oE 'dnsmasq-dnssec=~[0-9]+\.[0-9]+' "${BATS_TEST_DIRNAME}/../Dockerfile" | grep -oE '[0-9]+\.[0-9]+')"
+    [ -n "${expected_version}" ] || { echo "Could not extract dnsmasq version from Dockerfile" >&2; return 1; }
     run docker run --rm --entrypoint sh "${IMAGE}" -c 'dnsmasq --version 2>&1'
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2.91" ]]
+    [[ "$output" =~ "${expected_version}" ]]
 }
 
 @test "dnsmasq is built with DNSSEC support" {

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -15,10 +15,10 @@ IMAGE="${IMAGE_NAME:-pygmystack/dnsmasq:test}"
     [ -n "$output" ]
 }
 
-@test "dnsmasq version is 2.85.x" {
+@test "dnsmasq version is 2.91.x" {
     run docker run --rm --entrypoint sh "${IMAGE}" -c 'dnsmasq --version 2>&1'
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2.85" ]]
+    [[ "$output" =~ "2.91" ]]
 }
 
 @test "dnsmasq is built with DNSSEC support" {


### PR DESCRIPTION
This pull request updates the base image and the `dnsmasq` version used in the Docker image, along with the corresponding test to reflect the new version. The update also includes a minor configuration change to the `dnsmasq` setup.

Base image and dependency updates:

* Updated the Docker base image from `alpine:3.14` to `alpine:3.23` for improved security and compatibility.
* Upgraded `dnsmasq-dnssec` from version `2.85` to `2.91` in the Dockerfile to use the latest features and fixes.

Configuration changes:

* Modified `/etc/dnsmasq.conf` to comment out the `local-service` directive, to revert introduced network binding behavior.

Test updates:

* Updated the test in `image_structure.bats` to check for `dnsmasq` version `2.91.x` instead of `2.85.x`, ensuring tests match the new version.